### PR TITLE
Add `openrgb.load_profile` action

### DIFF
--- a/custom_components/openrgb/const.py
+++ b/custom_components/openrgb/const.py
@@ -11,6 +11,9 @@ ORGB_DISCOVERY_NEW = "openrgb_discovery_new_{}"
 
 SERVICE_FORCE_UPDATE = "force_update"
 SERVICE_PULL_DEVICES = "pull_devices"
+SERVICE_LOAD_PROFILE = "load_profile"
+
+ATTR_PROFILE = "profile"
 
 ENTRY_IS_SETUP = "openrgb_entry_is_setup"
 

--- a/custom_components/openrgb/services.yaml
+++ b/custom_components/openrgb/services.yaml
@@ -2,19 +2,19 @@
 
 pull_devices:
   name: Pull devices
-  description: Pull device list from OpenRGB server.
+  description: Pulls device list from OpenRGB server.
 
 force_update:
   name: Force update
-  description: Force all OpenRGB devices to pull data.
+  description: Forces all OpenRGB devices to pull data.
 
 load_profile:
   name: Load profile
-  description: Load profile in OpenRGB server
+  description: Load a profile on OpenRGB server.
   fields:
     profile:
       name: Profile
-      description: The name of the profile to load in the OpenRGB server
+      description: The name of the profile to load.
       required: true
       selector:
         text:

--- a/custom_components/openrgb/services.yaml
+++ b/custom_components/openrgb/services.yaml
@@ -1,15 +1,19 @@
 # Describes the format for available OpenRGB services
 
 pull_devices:
+  name: Pull devices
   description: Pull device list from OpenRGB server.
 
 force_update:
+  name: Force update
   description: Force all OpenRGB devices to pull data.
 
 load_profile:
+  name: Load profile
   description: Load profile in OpenRGB server
   fields:
     profile:
+      name: Profile
       description: The name of the profile to load in the OpenRGB server
       required: true
       selector:

--- a/custom_components/openrgb/services.yaml
+++ b/custom_components/openrgb/services.yaml
@@ -5,3 +5,12 @@ pull_devices:
 
 force_update:
   description: Force all OpenRGB devices to pull data.
+
+load_profile:
+  description: Load profile in OpenRGB server
+  fields:
+    profile:
+      description: The name of the profile to load in the OpenRGB server
+      required: true
+      selector:
+        text:


### PR DESCRIPTION
Note that there is no option to select which integration entry to load the profile on, meaning it will probably not work as intended if you have multiple integration entries.

However, from what I can tell, the other services also have the same issue.

I would recommend to accept this one, which will help most users a lot, and then improve later.

Closes #22
